### PR TITLE
fix cimport for setuptools

### DIFF
--- a/src/pcre2.pyx
+++ b/src/pcre2.pyx
@@ -4,7 +4,7 @@ from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 from libc.stdint cimport uint32_t
 from libc.string cimport memcpy, memset, strlen
 
-cimport _pcre2
+from src cimport _pcre2
 
 ctypedef int(*match_func_type)(
         const _pcre2.pcre2_code *,


### PR DESCRIPTION
When installing your package directly with pip, an error occurs : 

```
sudo pip3 install git+https://github.com/gpfei/python-pcre2

    Error compiling Cython file:
    ------------------------------------------------------------
    ...
    # cython: c_string_type=unicode, c_string_encoding=utf8
    from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
    from libc.stdint cimport uint32_t
    from libc.string cimport memcpy, memset, strlen
    
    cimport _pcre2
           ^
    ------------------------------------------------------------
    
    src/pcre2.pyx:7:8: '_pcre2.pxd' not found
```

With my change, it works : 

```
pip3 install git+https://github.com/whuji/python-pcre2

Collecting git+https://github.com/whuji/python-pcre2
  Cloning https://github.com/whuji/python-pcre2 to /tmp/pip-req-build-q2loygtz
Requirement already satisfied (use --upgrade to upgrade): pcre2==0.1 from git+https://github.com/whuji/python-pcre2 in /usr/local/lib/python3.7/dist-packages/pcre2-0.1-py3.7-linux-x86_64.egg
Requirement already satisfied: Cython in /usr/lib/python3/dist-packages (from pcre2==0.1) (0.29.2)
Building wheels for collected packages: pcre2
  Building wheel for pcre2 (setup.py) ... done
  Stored in directory: /tmp/pip-ephem-wheel-cache-zgokxm18/wheels/8d/c8/44/fd6f7157de1dd619b1fdf09f71b22035a2d137d0493b1cf45a
Successfully built pcre2

```