### PR TITLE
Export pcre2_dfa_match function

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple Python wrapper of [PCRE2](http://www.pcre.org/)
 ### Requirements
 - Python 3.5+
 - Cython
-- libpcre2
+- libpcre2 + header file
 
 
 ### Example

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
 
-from Cython.Build import cythonize
+#from Cython.Build import cythonize
 
 
 extensions = [
@@ -30,11 +30,16 @@ setup(
         ],
     },
 
+    setup_requires = [
+        'setuptools>=18.0',
+        'cython',
+    ], 
+
     install_requires = [
         'Cython',
     ],
 
-    ext_modules = cythonize(extensions),
+    ext_modules = extensions,
 
     author = 'Gu Pengfei',
     author_email = 'gpfei96@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extensions = [
 
 setup(
     name = 'pcre2',
-    version = '0.1',
+    version = '0.2',
     packages = find_packages(),
     include_package_data = True,
 

--- a/src/_pcre2.pxd
+++ b/src/_pcre2.pxd
@@ -63,6 +63,8 @@ cdef extern from "pcre2.h":
     # compile and match
     pcre2_code *pcre2_compile(PCRE2_SPTR, PCRE2_SIZE, uint32_t, int *, PCRE2_SIZE *, pcre2_compile_context *)
     int pcre2_match(const pcre2_code *, PCRE2_SPTR, PCRE2_SIZE, PCRE2_SIZE, uint32_t, pcre2_match_data *, pcre2_match_context *)
+    # Alternative algorithm (said DFA but rather TNFA)
+    int pcre2_dfa_match(const pcre2_code *, PCRE2_SPTR, PCRE2_SIZE, PCRE2_SIZE, uint32_t, pcre2_match_data *, pcre2_match_context *, int*, PCRE2_SIZE)
     # jit
     int pcre2_jit_compile(pcre2_code *, uint32_t)
     int pcre2_jit_match(const pcre2_code *, PCRE2_SPTR, PCRE2_SIZE, PCRE2_SIZE, uint32_t, pcre2_match_data *, pcre2_match_context *)


### PR DESCRIPTION
Hello again,

I have added the possibility to use pcre2_dfa_match function.
It enables to use the PCRE2 alternative algorithm (which is not a DFA actually, but a TNFA, but the author didn't seem to know this algo).

The advantage of this algorithm is that is runs in linear time, always. No explosive regex.
But it lacks of some feature (no backreference, no capturing).

To use it, add 'use_alternative_algorithm=True' at the pcre2.PCRE2 constructor argument.

man pcre2matching